### PR TITLE
fix: wrong destination repo address of History-spoke workflow

### DIFF
--- a/.github/workflows/history-spoke.yml
+++ b/.github/workflows/history-spoke.yml
@@ -13,6 +13,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.PAT }}
-          repository: Simle2Buy/.github # dest: Hub 브랜치
+          repository: Smile2Buy/.github # dest: Hub 브랜치
           event-type: readme_updated    # 약속된 이벤트
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@
     - [x] NAT Gateway & Elastic IP
     - [x] Route-table & Route-table-association
 
+### GitOps
+- [x] AutoLabel -- Attach labels of type and domain to the opened PR
+- [x] ReleaseDrafter -- Build a drafter of release note when code push to [main] branch occurs
+- [x] HistorySpoke -- Send message to Hisory-hub repository when README.md has been changed
+
 ### CDK Implementation
 
 ## FIXME


### PR DESCRIPTION
## Done
- GitOps 관련 작업내역 업데이트
- 잘못된 Hub 레포 주소 수정